### PR TITLE
DEVENGAGE-2251 dx-ui compatibility

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,7 +15,7 @@
 				"@types/node": "^12.0.0",
 				"@types/react": "^18.0.21",
 				"@types/react-dom": "^18.0.6",
-				"genesys-dev-icons": "^0.3.1",
+				"genesys-dev-icons": "^0.4.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-scripts": "5.0.1",
@@ -7601,9 +7601,9 @@
 			}
 		},
 		"node_modules/genesys-dev-icons": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/genesys-dev-icons/-/genesys-dev-icons-0.3.1.tgz",
-			"integrity": "sha512-Pn+Iu1WWF956FEmfOOV11tkjgaBN0TvsTUxsfbP/6rB3Rp3L5vcw7PT2+bxdxEPgS05b/ZGv5gprtjj2rHfkpA==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/genesys-dev-icons/-/genesys-dev-icons-0.4.0.tgz",
+			"integrity": "sha512-mKGugDHZ/qNzrJ1VqPfDKaRl7c4qe3fwkXIFzlQyCLXa/uyhxke41+Ap9Tp7pwk5888IGmjkFG9V2olpfumE4w==",
 			"peerDependencies": {
 				"react": ">=16",
 				"react-dom": ">=16"
@@ -20546,9 +20546,9 @@
 			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
 		},
 		"genesys-dev-icons": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/genesys-dev-icons/-/genesys-dev-icons-0.3.1.tgz",
-			"integrity": "sha512-Pn+Iu1WWF956FEmfOOV11tkjgaBN0TvsTUxsfbP/6rB3Rp3L5vcw7PT2+bxdxEPgS05b/ZGv5gprtjj2rHfkpA==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/genesys-dev-icons/-/genesys-dev-icons-0.4.0.tgz",
+			"integrity": "sha512-mKGugDHZ/qNzrJ1VqPfDKaRl7c4qe3fwkXIFzlQyCLXa/uyhxke41+Ap9Tp7pwk5888IGmjkFG9V2olpfumE4w==",
 			"requires": {}
 		},
 		"gensync": {

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,7 @@
 		"@types/node": "^12.0.0",
 		"@types/react": "^18.0.21",
 		"@types/react-dom": "^18.0.6",
-		"genesys-dev-icons": "^0.3.1",
+		"genesys-dev-icons": "^0.4.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-scripts": "5.0.1",

--- a/package/package.json
+++ b/package/package.json
@@ -10,6 +10,7 @@
 		"directory": "package"
 	},
 	"types": "lib/index.d.ts",
+	"main": "./lib/index.js",
 	"exports": {
 		"require": "./src/index.ts",
 		"default": "./lib/index.js"

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "genesys-dev-icons",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"private": false,
 	"description": "This project amalgamates public-facing Genesys brand icons, Genesys product icons, and general application iconography into a packaged icon library.",
 	"homepage": "https://purecloudlabs.github.io/genesys-dev-icon-pack",


### PR DESCRIPTION
Adds main field to package.json for compatibility with dx-ui.

From [node docs](https://nodejs.org/api/packages.html#:~:text=If%20both%20%22exports%22%20and%20%22,via%20require%20or%20via%20import%20.):
>If both "exports" and "main" are defined, the "exports" field takes precedence over "main" in supported versions of Node.js.

I also installed the preview versions in yeti-cms and it ran locally without issue.